### PR TITLE
feat(kde): Enable NumLock on startup

### DIFF
--- a/kcminputrc
+++ b/kcminputrc
@@ -1,3 +1,5 @@
 [Mouse]
 XlIbInptAccelProfileFlat=true
 XLbInptPointerAcceleration=1
+[Keyboard]
+NumLock=1


### PR DESCRIPTION
Updates kcminputrc to ensure the number pad is automatically enabled when the desktop session starts.